### PR TITLE
Add missing using statements

### DIFF
--- a/Space Navigator Unity project/Assets/SpaceNavigator/Plugins/SpaceNavigatorMac.cs
+++ b/Space Navigator Unity project/Assets/SpaceNavigator/Plugins/SpaceNavigatorMac.cs
@@ -1,3 +1,7 @@
+using System.Runtime.InteropServices;
+using UnityEngine;
+using System;
+
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
 public class SpaceNavigatorMac : SpaceNavigator {
 	private const float TransSensScale = 0.007f, RotSensScale = 0.025f;


### PR DESCRIPTION
Package was throwing errors on OSX 10.10.5. Adding a few using statements to SpaceNavigatorMac.cs fixed the problem and allowed the plugin to run. 