### PR TITLE
Customizable dead zone on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ Temp/
 Thumbs.db
 Thumbs.db.meta
 
+#ignore thumbnails created by OSX
+.DS_Store
+
 #Ignore files build by Visual Studio
 *.sln
 *.sln.DotSettings

--- a/Space Navigator Unity project/Assets/SpaceNavigator/Plugins/SpaceNavigator.cs
+++ b/Space Navigator Unity project/Assets/SpaceNavigator/Plugins/SpaceNavigator.cs
@@ -98,6 +98,18 @@ public abstract class SpaceNavigator : IDisposable {
 	public float RotSensMin = RotSensMinDefault;
 	public float RotSensMax = RotSensMaxDefault;
 
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+	public const float RotDeadDefault = 30, RotDeadMinDefault = 0, RotDeadMaxDefault = 100f;
+	public float RotDead = RotDeadDefault;
+	public float RotDeadMin = RotDeadMinDefault;
+	public float RotDeadMax = RotDeadMaxDefault;
+
+	public const float TransDeadDefault = 30, TransDeadMinDefault = 0, TransDeadMaxDefault = 100f;
+	public float TransDead = TransDeadDefault;
+	public float TransDeadMin = TransDeadMinDefault;
+	public float TransDeadMax = TransDeadMaxDefault;
+#endif
+
 	// Setting storage keys
 	private const string TransSensKey = "Translation sensitivity";
 	private const string TransSensMinKey = "Translation sensitivity minimum";
@@ -114,6 +126,16 @@ public abstract class SpaceNavigator : IDisposable {
 	private const string LockRotationXKey = "Rotation lock X";
 	private const string LockRotationYKey = "Rotation lock Y";
 	private const string LockRotationZKey = "Rotation lock Z";
+
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+	private const string TransDeadKey = "Translation dead zone size";
+	private const string TransDeadMinKey = "Translation dead zone size minimum";
+	private const string TransDeadMaxKey = "Translation dead zone size maximum";
+
+	private const string RotDeadKey = "Rotation dead zone size";
+	private const string RotDeadMinKey = "Rotation dead zone size minimum";
+	private const string RotDeadMaxKey = "Rotation dead zone size maximum";
+#endif
 	#region - Singleton -
 	public static SpaceNavigator Instance {
 		get {
@@ -213,6 +235,41 @@ public abstract class SpaceNavigator : IDisposable {
 
 		GUILayout.EndHorizontal();
 		#endregion - Sensitivity + gearbox -
+
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+		#region - Dead Zone -
+		GUILayout.BeginVertical();
+		GUILayout.Label("Dead Zone");
+		GUILayout.Space(4);
+
+
+		#region - Translation + rotation -
+		GUILayout.BeginVertical();
+		#region - Translation -
+		GUILayout.BeginHorizontal();
+		GUILayout.Label("Translation", GUILayout.Width(67));
+		TransDead = EditorGUILayout.FloatField(TransDead, GUILayout.Width(30));
+		TransDeadMin = EditorGUILayout.FloatField(TransDeadMin, GUILayout.Width(30));
+		TransDead = GUILayout.HorizontalSlider(TransDead, TransDeadMin, TransDeadMax);
+		TransDeadMax = EditorGUILayout.FloatField(TransDeadMax, GUILayout.Width(30));
+		GUILayout.EndHorizontal();
+		#endregion - Translation -
+
+		#region - Rotation -
+		GUILayout.BeginHorizontal();
+		GUILayout.Label("Rotation", GUILayout.Width(67));
+		RotDead = EditorGUILayout.FloatField(RotDead, GUILayout.Width(30));
+		RotDeadMin = EditorGUILayout.FloatField(RotDeadMin, GUILayout.Width(30));
+		RotDead = GUILayout.HorizontalSlider(RotDead, RotDeadMin, RotDeadMax);
+		RotDeadMax = EditorGUILayout.FloatField(RotDeadMax, GUILayout.Width(30));
+		GUILayout.EndHorizontal();
+		#endregion - Rotation -
+		GUILayout.EndVertical();
+		#endregion - Translation + rotation -
+
+		GUILayout.EndVertical();
+#endregion - Deadzone -
+
 #endif
 	}
 
@@ -234,6 +291,16 @@ public abstract class SpaceNavigator : IDisposable {
 		RotSens = PlayerPrefs.GetFloat(RotSensKey, RotSensDefault);
 		RotSensMin = PlayerPrefs.GetFloat(RotSensMinKey, RotSensMinDefault);
 		RotSensMax = PlayerPrefs.GetFloat(RotSensMaxKey, RotSensMaxDefault);
+
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+		RotDead = PlayerPrefs.GetFloat(RotDeadKey, RotDeadDefault);
+		RotDeadMin = PlayerPrefs.GetFloat(RotDeadMinKey, RotDeadMinDefault);
+		RotDeadMax = PlayerPrefs.GetFloat(RotDeadMaxKey, RotDeadMaxDefault);
+
+		TransDead = PlayerPrefs.GetFloat(TransDeadKey, TransDeadDefault);
+		TransDeadMin = PlayerPrefs.GetFloat(TransDeadMinKey, TransDeadMinDefault);
+		TransDeadMax = PlayerPrefs.GetFloat(TransDeadMaxKey, TransDeadMaxDefault);
+#endif
 
 		_lockRotationAll = PlayerPrefs.GetInt(LockRotationAllKey, 0) == 1;
 		_lockRotationX = PlayerPrefs.GetInt(LockRotationXKey, 0) == 1;
@@ -257,6 +324,16 @@ public abstract class SpaceNavigator : IDisposable {
 		PlayerPrefs.SetFloat(RotSensKey, RotSens);
 		PlayerPrefs.SetFloat(RotSensMinKey, RotSensMin);
 		PlayerPrefs.SetFloat(RotSensMaxKey, RotSensMax);
+
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+		PlayerPrefs.SetFloat(RotDeadKey, RotDead);
+		PlayerPrefs.SetFloat(RotDeadMinKey, RotDeadMin);
+		PlayerPrefs.SetFloat(RotDeadMaxKey, RotDeadMax);
+
+		PlayerPrefs.SetFloat(TransDeadKey, TransDead);
+		PlayerPrefs.SetFloat(TransDeadMinKey, TransDeadMin);
+		PlayerPrefs.SetFloat(TransDeadMaxKey, TransDeadMax);
+#endif
 
 		PlayerPrefs.SetInt(LockRotationAllKey, _lockRotationAll ? 1 : 0);
 		PlayerPrefs.SetInt(LockRotationXKey, _lockRotationX ? 1 : 0);

--- a/Space Navigator Unity project/Assets/SpaceNavigator/Plugins/SpaceNavigatorMac.cs
+++ b/Space Navigator Unity project/Assets/SpaceNavigator/Plugins/SpaceNavigatorMac.cs
@@ -31,13 +31,13 @@ public class SpaceNavigatorMac : SpaceNavigator {
 		SampleTranslation(ref x, ref y, ref z);
 		float sensitivity = Application.isPlaying ? PlayTransSens : TransSens[CurrentGear];
 		
-	return (
-		_clientID == 0 ?
+		return (
+		    _clientID == 0 ?
 		Vector3.zero :
-		new Vector3(
-			LockTranslationX || LockTranslationAll ? 0 : SubtractDeadzone(x, TranslationDeadzone),
-			LockTranslationY || LockTranslationAll ? 0 : SubtractDeadzone(-z, TranslationDeadzone),
-			LockTranslationZ || LockTranslationAll ? 0 : SubtractDeadzone(-y, TranslationDeadzone)) * sensitivity * TransSensScale);
+		new Vector3 (
+			    LockTranslationX || LockTranslationAll ? 0 : SubtractDeadzone (x, TransDead),
+			    LockTranslationY || LockTranslationAll ? 0 : SubtractDeadzone (-z, TransDead),
+			    LockTranslationZ || LockTranslationAll ? 0 : SubtractDeadzone (-y, TransDead)) * sensitivity * TransSensScale);
 	}
 	public override Quaternion GetRotation() {
 		int rx = 0, ry = 0, rz = 0;
@@ -49,16 +49,16 @@ public class SpaceNavigatorMac : SpaceNavigator {
 			Quaternion.identity :
 			Quaternion.Euler(
 				new Vector3(
-					LockRotationX || LockRotationAll ? 0 : SubtractDeadzone(-rx, RotationDeadzone),
-					LockRotationY || LockRotationAll ? 0 : SubtractDeadzone(rz, RotationDeadzone),
-					LockRotationZ || LockRotationAll ? 0 : SubtractDeadzone(ry, RotationDeadzone)) * sensitivity * RotSensScale));
+					LockRotationX || LockRotationAll ? 0 : SubtractDeadzone(-rx, RotDead),
+					LockRotationY || LockRotationAll ? 0 : SubtractDeadzone(rz, RotDead),
+					LockRotationZ || LockRotationAll ? 0 : SubtractDeadzone(ry, RotDead)) * sensitivity * RotSensScale));
 	}
 
-	private float SubtractDeadzone(int value, int deadzone)
+	private float SubtractDeadzone(int value, float deadzone)
 	{
-		int signMultiplier = value < 0 ? -1 : 1;
-		int absoluteValue = Mathf.Abs(value);
-		return Mathf.Max(absoluteValue - Mathf.Abs(deadzone), 0) * signMultiplier;
+		return value < 0
+			? Math.Min(0, value + Math.Abs(deadzone))
+			: Math.Max(0, value - Math.Abs(deadzone));
 	}
 
 	#region - Singleton -

--- a/Space Navigator Unity project/Assets/SpaceNavigator/Plugins/SpaceNavigatorMac.cs
+++ b/Space Navigator Unity project/Assets/SpaceNavigator/Plugins/SpaceNavigatorMac.cs
@@ -22,43 +22,43 @@ public class SpaceNavigatorMac : SpaceNavigator {
 
 	private int _clientID;
 
+	private const int TranslationDeadzone = 30;
+	private const int RotationDeadzone = 30;
+
 	// Public API
 	public override Vector3 GetTranslation() {
 		int x = 0, y = 0, z = 0;
 		SampleTranslation(ref x, ref y, ref z);
 		float sensitivity = Application.isPlaying ? PlayTransSens : TransSens[CurrentGear];
 		
-		// Workaround for drift on mac by Enrico Tuttobene.
-		if (Mathf.Abs(x) == 1) x = 0;
-		if (Mathf.Abs(y) == 1) y = 0;
-		if (Mathf.Abs(z) == 1) z = 0;
-
-		return (
-				   _clientID == 0 ?
-					   Vector3.zero :
-					   new Vector3(
-						   LockTranslationX || LockTranslationAll ? 0 : (float)x,
-						   LockTranslationY || LockTranslationAll ? 0 : -(float)z,
-						   LockTranslationZ || LockTranslationAll ? 0 : -(float)y) * sensitivity * TransSensScale);
+	return (
+		_clientID == 0 ?
+		Vector3.zero :
+		new Vector3(
+			LockTranslationX || LockTranslationAll ? 0 : SubtractDeadzone(x, TranslationDeadzone),
+			LockTranslationY || LockTranslationAll ? 0 : SubtractDeadzone(-z, TranslationDeadzone),
+			LockTranslationZ || LockTranslationAll ? 0 : SubtractDeadzone(-y, TranslationDeadzone)) * sensitivity * TransSensScale);
 	}
 	public override Quaternion GetRotation() {
 		int rx = 0, ry = 0, rz = 0;
 		SampleRotation(ref rx, ref ry, ref rz);
 		float sensitivity = Application.isPlaying ? PlayRotSens : RotSens;
 
-		// Workaround for drift on mac by Enrico Tuttobene.
-		if (Mathf.Abs(rx) == 1) rx = 0;
-		if (Mathf.Abs(ry) == 1) ry = 0;
-		if (Mathf.Abs(rz) == 1) rz = 0;
-
 		return (
-				   _clientID == 0 ?
-					   Quaternion.identity :
-					   Quaternion.Euler(
-						   new Vector3(
-							   LockRotationX || LockRotationAll ? 0 : -(float)rx,
-							   LockRotationY || LockRotationAll ? 0 : (float)rz,
-							   LockRotationZ || LockRotationAll ? 0 : (float)ry) * sensitivity * RotSensScale));
+			_clientID == 0 ?
+			Quaternion.identity :
+			Quaternion.Euler(
+				new Vector3(
+					LockRotationX || LockRotationAll ? 0 : SubtractDeadzone(-rx, RotationDeadzone),
+					LockRotationY || LockRotationAll ? 0 : SubtractDeadzone(rz, RotationDeadzone),
+					LockRotationZ || LockRotationAll ? 0 : SubtractDeadzone(ry, RotationDeadzone)) * sensitivity * RotSensScale));
+	}
+
+	private float SubtractDeadzone(int value, int deadzone)
+	{
+		int signMultiplier = value < 0 ? -1 : 1;
+		int absoluteValue = Mathf.Abs(value);
+		return Mathf.Max(absoluteValue - Mathf.Abs(deadzone), 0) * signMultiplier;
 	}
 
 	#region - Singleton -


### PR DESCRIPTION
With my SpacePilot, the check for an input of 1 was not enough to eliminate drift on OSX; I actually had to set it to around 30 to eliminate most of the drifting.  Since that value was relatively high, I also added some dead zone logic so that the lowest input that registers isn't 31 in my case, but it starts counting from zero outside of the dead zone.  I also added in some sliders so others can change the behavior as they see fit.