### PR TITLE
Update depreciated Callback for playModeStateChanges

### DIFF
--- a/Space Navigator Unity project/Assets/SpaceNavigator/Editor/ViewportController.cs
+++ b/Space Navigator Unity project/Assets/SpaceNavigator/Editor/ViewportController.cs
@@ -28,7 +28,7 @@ namespace SpaceNavigatorDriver {
 		static ViewportController() {
 			// Set up callbacks.
 			EditorApplication.update += Update;
-			EditorApplication.playmodeStateChanged += PlaymodeStateChanged;
+			EditorApplication.playModeStateChanged += e => PlaymodeStateChanged();
 
 			// Initialize.
 			Settings.Read();


### PR DESCRIPTION
This removes the yellow warning in Unity 2018.1 and up; restoring compatibility.