### PR TITLE
Camera-Speed adjustment relative to target distance

### DIFF
--- a/Space Navigator Unity project/Assets/SpaceNavigator/Editor/ViewportController.cs
+++ b/Space Navigator Unity project/Assets/SpaceNavigator/Editor/ViewportController.cs
@@ -110,6 +110,18 @@ namespace SpaceNavigatorDriver {
 		static void Fly(SceneView sceneView, Vector3 translationInversion, Vector3 rotationInversion) {
 			SyncRigWithScene();
 
+			
+			//calculate distance to selected object or world center, to adjust fly speed
+			Vector3 targetPosition = (Selection.activeTransform != null) ? Selection.activeTransform.position : new Vector3();
+			float distanceToTarget = (_camera.position - targetPosition).magnitude;
+			float flySpeedAdjustment = Mathf.Pow(distanceToTarget * 0.3f, 1.1f);
+			if (flySpeedAdjustment > 1000f) flySpeedAdjustment = 1000f; //limit maximum speed, so that camera cannot exit valid value-range too fast.
+			
+
+			// Apply inversion of axes for fly/grabmove mode.
+			Vector3 translation = Vector3.Scale(SpaceNavigator.Translation, translationInversion) * flySpeedAdjustment;
+			
+			
 			// Apply inversion of axes for fly/grabmove mode.
 			Vector3 translation = Vector3.Scale(SpaceNavigator.Translation, translationInversion);
 			Vector3 rotation = Vector3.Scale(SpaceNavigator.Rotation.eulerAngles, rotationInversion);


### PR DESCRIPTION
Hi, 

as the Unity scene view does not offer an appropriate camera-movement speed when beeing further away from objects, Ive added a small modification to the SpaceNav plugin, to do so.

It is just a simple exponential function, relativ to the distance of the selected object (or world center if none is selected)