### PR TITLE
Fix: Space Pilot PRO now working

### DIFF
--- a/Runtime/SpaceNavigatorHID.cs
+++ b/Runtime/SpaceNavigatorHID.cs
@@ -69,7 +69,7 @@ namespace SpaceNavigatorDriver
             InputSystem.RegisterLayout<SpaceNavigatorHID>(
                 matches: new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithManufacturer("3Dconnexion")
+                    .WithManufacturer("3Dconnexion.*")
                     .WithProduct(".*"));
             DebugLog("SpaceNavigator Driver : RegisterLayout");
         }


### PR DESCRIPTION
Surprise fix! I took another look at getting my trusty space pilot to work with the input system (#26), and randomly found the _actual_ issue it wasn't working:
![image](https://user-images.githubusercontent.com/2693840/122365739-39956e00-cf5b-11eb-9f57-a7801909a8f4.png)

For reasons beyond me the manufacturer and product name have spaces appended to them for the Pilot.
This PR simply changes the manufacturer match to "3Dconnexion.*" – and it works...

Fixes #26 