### PR TITLE
Add gameview focus setting

### DIFF
--- a/Editor/ViewportController.cs
+++ b/Editor/ViewportController.cs
@@ -25,6 +25,7 @@ namespace SpaceNavigatorDriver
         private static bool _wasHorizonLocked;
         private const float _saveInterval = 30;
         private static float _lastSaveTime;
+        private static Type GameView;
 
         static ViewportController()
         {
@@ -67,6 +68,14 @@ namespace SpaceNavigatorDriver
 
             // If we don't want the driver to navigate the editor at runtime, exit now.
             if (Application.isPlaying && !Settings.RuntimeEditorNav) return;
+
+            if (GameView == null)
+            {
+                var assembly = typeof(UnityEditor.EditorWindow).Assembly;
+                GameView = assembly.GetType("UnityEditor.GameView");
+            }
+
+            if (Application.isPlaying && Settings.RuntimeEditorNav && !Settings.RuntimeEditorNavWithFocussedGameView && GameView.IsAssignableFrom(EditorWindow.focusedWindow?.GetType())) return;
 
             SceneView sceneView = SceneView.lastActiveSceneView;
             if (!sceneView) return;

--- a/Runtime/Settings/Settings.cs
+++ b/Runtime/Settings/Settings.cs
@@ -62,6 +62,7 @@ namespace SpaceNavigatorDriver {
 
 		// Runtime editor navigation
 		public static bool RuntimeEditorNav = true;
+		public static bool RuntimeEditorNavWithFocussedGameView = true;
 
 		// Inversion
 		public static Vector3 FlyInvertTranslation, FlyInvertRotation;
@@ -227,8 +228,13 @@ namespace SpaceNavigatorDriver {
 			GUILayout.EndHorizontal();
 			#endregion - Sensitivity + gearbox -
 
+			GUILayout.BeginHorizontal();
 			RuntimeEditorNav = GUILayout.Toggle(RuntimeEditorNav, "Runtime Editor Navigation");
-
+			EditorGUI.BeginDisabledGroup(!RuntimeEditorNav);
+			RuntimeEditorNavWithFocussedGameView = GUILayout.Toggle(RuntimeEditorNavWithFocussedGameView, "On GameView focus");
+			EditorGUI.EndDisabledGroup();
+			GUILayout.EndHorizontal();
+			
 			#region - Axes inversion per mode -
 			GUILayout.Space(10);
 			GUILayout.Label("Invert axes in " + Settings.Mode.ToString() + " mode");
@@ -386,6 +392,7 @@ namespace SpaceNavigatorDriver {
 			PlayerPrefs.SetFloat("Rotation sensitivity maximum", RotSensMax);
 			// Runtime Editor Navigation
 			PlayerPrefs.SetInt("RuntimeEditorNav", RuntimeEditorNav ? 1 : 0);
+			PlayerPrefs.SetInt("RuntimeEditorNavWithFocussedGameView", RuntimeEditorNavWithFocussedGameView ? 1 : 0);
 			// Axis Inversions
 			WriteAxisInversions(FlyInvertTranslation, FlyInvertRotation, "Fly");
 			WriteAxisInversions(OrbitInvertTranslation, OrbitInvertRotation, "Orbit");
@@ -426,6 +433,7 @@ namespace SpaceNavigatorDriver {
 			RotSensMax = PlayerPrefs.GetFloat("Rotation sensitivity maximum", RotSensMaxDefault);
 			// Runtime Editor Navigation
 			RuntimeEditorNav = PlayerPrefs.GetInt("RuntimeEditorNav", 1) == 1;
+			RuntimeEditorNavWithFocussedGameView = PlayerPrefs.GetInt("RuntimeEditorNavWithFocussedGameView", 1) == 1;
 			// Axis Inversions
 			ReadAxisInversions(ref FlyInvertTranslation, ref FlyInvertRotation, "Fly");
 			ReadAxisInversions(ref OrbitInvertTranslation, ref OrbitInvertRotation, "Orbit");


### PR DESCRIPTION
This PR adds a new setting for runtime navigation that prevents scene view navigation only when the game view is focussed.
Rationale: when using a runtime navigation model (e.g. FlyAround), scene view navigation should still be possible, only not when the game view is currently active. Otherwise this leads to "double navigation" in both windows.

If you think this is actually the same intent as "Runtime Nav" happy to change this PR to add the focus condition to that instead.