### PR TITLE
Fix: package version of -beta being lower than -debug, follow UPM lifecycle rules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.pathightree.spacenavigator-driver",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-pre",
   "displayName": "SpaceNavigator Driver",
   "description": "Driver for 3DConnexion devices\nThis driver lets you fly around your scene and allows you to move items around.\nIt can also be used at runtime via scripting.",
   "unity": "2019.1",


### PR DESCRIPTION
Currently, the released versions are -beta.1 to .7 and -debug.
According to SemVer rules that means -debug is the newest one, which isn't on purpose here;
this PR fixes the version and follows Unity UPM lifecycle rules (for example 2.0.0-exp, 2.0.0-pre, 2.0.0-pre.2, 2.0.0-rc, 2.0.0, 2.0.1-pre, 2.0.1).