### PR TITLE
Fixed scene view camera small input issue #29

### DIFF
--- a/Editor/ViewportController.cs
+++ b/Editor/ViewportController.cs
@@ -87,8 +87,8 @@ namespace SpaceNavigatorDriver
             _wasHorizonLocked = Settings.LockHorizon;
 
             // Return if device is idle.
-            if (SpaceNavigatorHID.current.Translation.ReadValue() == Vector3.zero &&
-                SpaceNavigatorHID.current.Rotation.ReadValue() == Vector3.zero)
+            if (ApproximatelyEqual(SpaceNavigatorHID.current.Translation.ReadValue(), Vector3.zero, Settings.TransSensEpsilon) &&
+                ApproximatelyEqual(SpaceNavigatorHID.current.Rotation.ReadValue(), Vector3.zero, Settings.RotSensEpsilon))
             {
                 _wasIdle = true;
                 return;
@@ -431,6 +431,19 @@ namespace SpaceNavigatorDriver
         }
 
         #endregion - Snapping -
+        
+        #region - Calibration -
+        
+        private static bool ApproximatelyEqual(Vector3 lhs, Vector3 rhs, float epsilon)
+        {
+            float num = lhs.x - rhs.x;
+            float num2 = lhs.y - rhs.y;
+            float num3 = lhs.z - rhs.z;
+            float num4 = num * num + num2 * num2 + num3 * num3;
+            return num4 < (9.99999944f * Mathf.Pow(10, -epsilon));
+        }
+
+        #endregion - Calibration -
     }
 }
 #endif

--- a/Runtime/Settings/Settings.cs
+++ b/Runtime/Settings/Settings.cs
@@ -70,6 +70,12 @@ namespace SpaceNavigatorDriver {
 		public static Vector3 TelekinesisInvertTranslation, TelekinesisInvertRotation;
 		public static Vector3 GrabMoveInvertTranslation, GrabMoveInvertRotation;
 
+		// Calibration
+		public const float TransSensEpsilonDefault = 11f;
+		public static float TransSensEpsilon = TransSensEpsilonDefault;
+		public const float RotSensEpsilonDefault = 11f;
+		public static float RotSensEpsilon = RotSensEpsilonDefault;
+
 		private static Vector2 _scrollPos;
 
 		static Settings() {
@@ -316,6 +322,29 @@ namespace SpaceNavigatorDriver {
 			GUILayout.EndHorizontal();
 			#endregion - Axes inversion per mode -
 
+			#region - Calibration -
+			GUILayout.Space(10);
+			GUILayout.BeginVertical();
+			GUILayout.Label("Calibration");
+			GUILayout.Space(4);
+						
+			#region - Translation Epsilon -
+			GUILayout.BeginHorizontal();
+			GUILayout.Label("Translation Epsilon", GUILayout.Width(120));
+			TransSensEpsilon = EditorGUILayout.FloatField(TransSensEpsilon, GUILayout.Width(30));
+			GUILayout.EndHorizontal();			
+			#endregion - Translation Epsilon -
+			
+			#region - Rotation Epsilon -
+			GUILayout.BeginHorizontal();
+			GUILayout.Label("Rotation Epsilon", GUILayout.Width(120));
+			RotSensEpsilon = EditorGUILayout.FloatField(RotSensEpsilon, GUILayout.Width(30));
+			GUILayout.EndHorizontal();
+			#endregion - Rotation Epsilon -
+
+			GUILayout.EndVertical();			
+			#endregion - Calibration -
+
 			#region - Dead Zone -
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
 		GUILayout.BeginVertical();
@@ -398,6 +427,9 @@ namespace SpaceNavigatorDriver {
 			WriteAxisInversions(OrbitInvertTranslation, OrbitInvertRotation, "Orbit");
 			WriteAxisInversions(TelekinesisInvertTranslation, TelekinesisInvertRotation, "Telekinesis");
 			WriteAxisInversions(GrabMoveInvertTranslation, GrabMoveInvertRotation, "Grab move");
+			// Calibration
+			PlayerPrefs.SetFloat("Translation sensitivity epsilon", TransSensEpsilon);
+			PlayerPrefs.SetFloat("Rotation sensitivity epsilon", RotSensEpsilon);
 		}
 
 		/// <summary>
@@ -439,6 +471,9 @@ namespace SpaceNavigatorDriver {
 			ReadAxisInversions(ref OrbitInvertTranslation, ref OrbitInvertRotation, "Orbit");
 			ReadAxisInversions(ref TelekinesisInvertTranslation, ref TelekinesisInvertRotation, "Telekinesis");
 			ReadAxisInversions(ref GrabMoveInvertTranslation, ref GrabMoveInvertRotation, "Grab move");
+			// Calibration
+			TransSensEpsilon = PlayerPrefs.GetFloat("Translation sensitivity epsilon", TransSensEpsilonDefault);
+			RotSensEpsilon = PlayerPrefs.GetFloat("Rotation sensitivity epsilon", RotSensEpsilonDefault);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Hi Pat,

the default epsilon `9.99999944E-11f` used by Unity when comparing two `Vector3` objects seems to be too small. At least in some cases. Therefore, I added options to adjust the translation and rotation epsilon. 

For easier configuration, only the exponent has to be entered. In my case a value around 5 to 7 solved the movement. When changing back to the default value 11, the movement reappeared.

Stefan