### PR TITLE
fix editor delta time

### DIFF
--- a/Editor/ViewportController.cs
+++ b/Editor/ViewportController.cs
@@ -1,436 +1,331 @@
-﻿#if UNITY_EDITOR
-using System;
+﻿using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
-namespace SpaceNavigatorDriver
-{
-    [InitializeOnLoad]
-    [Serializable]
-    class ViewportController
-    {
-        // Snapping
-        private static Dictionary<Transform, Quaternion> _unsnappedRotations = new Dictionary<Transform, Quaternion>();
-        private static Dictionary<Transform, Vector3> _unsnappedTranslations = new Dictionary<Transform, Vector3>();
-        private static bool _wasIdle;
+namespace SpaceNavigatorDriver {
 
-        // Rig components
-        private static GameObject _pivotGO, _cameraGO;
-        private static Transform _pivot, _camera;
-        private const string PivotName = "Scene camera pivot dummy";
-        private const string CameraName = "Scene camera dummy";
+	[InitializeOnLoad]
+	[Serializable]
+	class ViewportController {
 
-        private static bool _wasHorizonLocked;
-        private const float _saveInterval = 30;
-        private static float _lastSaveTime;
-        private static Type GameView;
+		// Snapping
+		private static Dictionary<Transform, Quaternion> _unsnappedRotations = new Dictionary<Transform, Quaternion>();
+		private static Dictionary<Transform, Vector3> _unsnappedTranslations = new Dictionary<Transform, Vector3>();
+		private static bool _wasIdle;
 
-        static ViewportController()
-        {
-            // Set up callbacks.
-            EditorApplication.update += Update;
-            EditorApplication.playModeStateChanged += e => PlaymodeStateChanged();
+		// Rig components
+		private static GameObject _pivotGO, _cameraGO;
+		private static Transform _pivot, _camera;
+		private const string PivotName = "Scene camera pivot dummy";
+		private const string CameraName = "Scene camera dummy";
 
-            // Initialize.
-            Settings.Read();
-            InitCameraRig();
-            StoreSelectionTransforms();
-        }
+		private static bool _wasHorizonLocked;
+		private const float _saveInterval = 30;
+		private static float _lastSaveTime;
 
-        #region - Callbacks -
+		private static double _lastRefreshTime;
+		private static double _diyDeltaTime;
 
-        private static void PlaymodeStateChanged()
-        {
-            if (EditorApplication.isPlayingOrWillChangePlaymode && !EditorApplication.isPlaying)
-                Settings.Write();
-        }
+		static ViewportController() {
+			// Set up callbacks.
+			EditorApplication.update += Update;
+			EditorApplication.playmodeStateChanged += PlaymodeStateChanged;
 
-        public static void OnApplicationQuit()
-        {
-            Settings.Write();
-            DisposeCameraRig();
-        }
+			// Initialize.
+			Settings.Read();
+			InitCameraRig();
+			StoreSelectionTransforms();
+		}
 
-        #endregion - Callbacks -
+		#region - Callbacks -
+		private static void PlaymodeStateChanged() {
+			if (EditorApplication.isPlayingOrWillChangePlaymode && !EditorApplication.isPlaying)
+				Settings.Write();
+		}
 
-        static void Update()
-        {
-            if (SpaceNavigatorHID.current == null) return;
+		public static void OnApplicationQuit() {
+			Settings.Write();
+			DisposeCameraRig();
+			SpaceNavigator.Instance.Dispose();
+		}
+		#endregion - Callbacks -
 
-            // Autosave settings.
-            if (!Application.isPlaying && DateTime.Now.Second - _lastSaveTime > _saveInterval)
-            {
-                Settings.Write();
-                _lastSaveTime = DateTime.Now.Second;
-            }
+		static void Update() {
+			// Autosave settings.
+			if (!Application.isPlaying && DateTime.Now.Second - _lastSaveTime > _saveInterval) {
+				Settings.Write();
+				_lastSaveTime = DateTime.Now.Second;
+			}
 
-            // If we don't want the driver to navigate the editor at runtime, exit now.
-            if (Application.isPlaying && !Settings.RuntimeEditorNav) return;
+			// If we don't want the driver to navigate the editor at runtime, exit now.
+			if (Application.isPlaying && !Settings.RuntimeEditorNav) return;
 
-            if (GameView == null)
-            {
-                var assembly = typeof(UnityEditor.EditorWindow).Assembly;
-                GameView = assembly.GetType("UnityEditor.GameView");
-            }
+			SceneView sceneView = SceneView.lastActiveSceneView;
+			if (!sceneView) return;
 
-            if (Application.isPlaying && Settings.RuntimeEditorNav && Settings.RuntimeEditorNavSuspendOnGameViewFocus && GameView.IsAssignableFrom(EditorWindow.focusedWindow?.GetType())) return;
+			SyncRigWithScene();
 
-            SceneView sceneView = SceneView.lastActiveSceneView;
-            if (!sceneView) return;
+			if (Settings.LockHorizon && !_wasHorizonLocked)
+				StraightenHorizon();
+			_wasHorizonLocked = Settings.LockHorizon;
 
-            SyncRigWithScene();
+			// Return if device is idle.
+			if (SpaceNavigator.Translation == Vector3.zero &&
+				SpaceNavigator.Rotation == Quaternion.identity) {
+				_wasIdle = true;
+				return;
+			}
 
-            if (Settings.LockHorizon && !_wasHorizonLocked)
-                StraightenHorizon();
-            _wasHorizonLocked = Settings.LockHorizon;
+			switch (Settings.Mode) {
+				case OperationMode.Fly:
+					Fly(sceneView);
+					break;
+				case OperationMode.Orbit:
+					Orbit(sceneView);
+					break;
+				case OperationMode.Telekinesis:
+					// Manipulate the object free from the camera.
+					Telekinesis(sceneView);
+					break;
+				case OperationMode.GrabMove:
+					// Manipulate the object together with the camera.
+					GrabMove(sceneView);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
 
-            // Return if device is idle.
-            if (SpaceNavigatorHID.current.Translation.ReadValue() == Vector3.zero &&
-                SpaceNavigatorHID.current.Rotation.ReadValue() == Vector3.zero)
-            {
-                _wasIdle = true;
-                return;
-            }
+			//// Detect keyboard clicks (not working).
+			//if (Keyboard.IsKeyDown(1))
+			//	D.log("Button 0 pressed");
+			//if (Keyboard.IsKeyDown(2))
+			//	D.log("Button 1 pressed");
 
-            switch (Settings.Mode)
-            {
-                case OperationMode.Fly:
-                    Fly(sceneView);
-                    break;
-                case OperationMode.Orbit:
-                    Orbit(sceneView);
-                    break;
-                case OperationMode.Telekinesis:
-                    // Manipulate the object free from the camera.
-                    Telekinesis(sceneView);
-                    break;
-                case OperationMode.GrabMove:
-                    // Manipulate the object together with the camera.
-                    GrabMove(sceneView);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+			_diyDeltaTime = EditorApplication.timeSinceStartup - _lastRefreshTime;
+			Debug.Log($"Unity delta time: {Time.deltaTime} diy deltTime: {_diyDeltaTime}");
+			_lastRefreshTime = EditorApplication.timeSinceStartup;
 
-            //// Detect keyboard clicks (not working).
-            //if (Keyboard.IsKeyDown(1))
-            //	D.log("Button 0 pressed");
-            //if (Keyboard.IsKeyDown(2))
-            //	D.log("Button 1 pressed");
+			_wasIdle = false;
+		}
 
-            _wasIdle = false;
-        }
+		#region - Navigation -
+		static void Fly(SceneView sceneView) {
+			Fly(sceneView, Settings.FlyInvertTranslation, Settings.FlyInvertRotation);
+		}
+		static void Fly(SceneView sceneView, Vector3 translationInversion, Vector3 rotationInversion) {
+			SyncRigWithScene();
 
-        #region - Navigation -
+			// Apply inversion of axes for fly/grabmove mode.
+			Vector3 translation = Vector3.Scale(SpaceNavigator.Translation, translationInversion) * (float)_diyDeltaTime * 100f;
+			Vector3 rotation = Vector3.Scale(SpaceNavigator.Rotation.eulerAngles, rotationInversion);
 
-        static void Fly(SceneView sceneView)
-        {
-            Fly(sceneView, Settings.FlyInvertTranslation, Settings.FlyInvertRotation);
-        }
+			_camera.Translate(translation, Space.Self);
+			if (sceneView.orthographic)
+				sceneView.size -= translation.z;
+			else {
+				if (Settings.LockHorizon) {
+					// Perform azimuth in world coordinates.
+					_camera.Rotate(Vector3.up, rotation.y, Space.World);
+					// Perform pitch in local coordinates.
+					_camera.Rotate(Vector3.right, rotation.x, Space.Self);
+				} else {
+					// Default rotation method, applies the whole quaternion to the camera.
+					_camera.Rotate(rotation);
+				}
+			}
 
-        static void Fly(SceneView sceneView, Vector3 translationInversion, Vector3 rotationInversion)
-        {
-            SyncRigWithScene();
+			// Update sceneview pivot and repaint view.
+			sceneView.pivot = _pivot.position;
+			sceneView.rotation = _pivot.rotation;
+			sceneView.Repaint();
+		}
+		static void Orbit(SceneView sceneView) {
+			// If no object is selected don't orbit, fly instead.
+			if (Selection.gameObjects.Length == 0) {
+				Fly(sceneView);
+				return;
+			}
 
-            // Apply inversion of axes for fly/grabmove mode.
-            Vector3 translation = Vector3.Scale(SpaceNavigatorHID.current.Translation.ReadValue(), translationInversion);
-            Vector3 rotation = Vector3.Scale(SpaceNavigatorHID.current.Rotation.ReadValue(), rotationInversion);
+			SyncRigWithScene();
 
-            // Apply sensitivity
-            translation *= Settings.TransSens[Settings.CurrentGear];
-            rotation *= Settings.RotSens;
-            
-            // Apply locks
-            translation.Scale(Settings.GetLocks(DoF.Translation));
-            rotation.Scale(Settings.GetLocks(DoF.Rotation));
-            
-            _camera.Translate(translation, Space.Self);
-            if (sceneView.orthographic)
-                sceneView.size -= translation.z;
-            else
-            {
-                if (Settings.LockHorizon)
-                {
-                    // Perform azimuth in world coordinates.
-                    _camera.Rotate(Vector3.up, rotation.y, Space.World);
-                    // Perform pitch in local coordinates.
-                    _camera.Rotate(Vector3.right, rotation.x, Space.Self);
-                }
-                else
-                {
-                    // Default rotation method, applies the whole quaternion to the camera.
-                    _camera.Rotate(rotation);
-                }
-            }
+			// Apply inversion of axes for orbit mode.
+			Vector3 translation = Vector3.Scale(SpaceNavigator.Translation, Settings.OrbitInvertTranslation);
+			Vector3 rotation = Vector3.Scale(SpaceNavigator.Rotation.eulerAngles, Settings.OrbitInvertRotation);
 
-            // Update sceneview pivot and repaint view.
-            sceneView.pivot = _pivot.position;
-            sceneView.rotation = _pivot.rotation;
-            sceneView.Repaint();
-        }
+			_camera.Translate(translation, Space.Self);
 
-        static void Orbit(SceneView sceneView)
-        {
-            // If no object is selected don't orbit, fly instead.
-            if (Selection.gameObjects.Length == 0)
-            {
-                Fly(sceneView);
-                return;
-            }
+			if (Settings.LockHorizon) {
+				_camera.RotateAround(Tools.handlePosition, Vector3.up, rotation.y);
+				_camera.RotateAround(Tools.handlePosition, _camera.right, rotation.x);
+			} else {
+				_camera.RotateAround(Tools.handlePosition, _camera.up, rotation.y);
+				_camera.RotateAround(Tools.handlePosition, _camera.right, rotation.x);
+				_camera.RotateAround(Tools.handlePosition, _camera.forward, rotation.z);
+			}
 
-            SyncRigWithScene();
+			// Update sceneview pivot and repaint view.
+			sceneView.pivot = _pivot.position;
+			sceneView.rotation = _pivot.rotation;
+			sceneView.Repaint();
+		}
+		static void Telekinesis(SceneView sceneView) {
+			// Apply inversion of axes for telekinesis mode.
+			Vector3 translation = Vector3.Scale(SpaceNavigator.Translation, Settings.TelekinesisInvertTranslation);
+			Quaternion rotation = Quaternion.Euler(Vector3.Scale(SpaceNavigator.Rotation.eulerAngles, Settings.TelekinesisInvertRotation));
 
-            // Apply inversion of axes for orbit mode.
-            Vector3 translation = Vector3.Scale(SpaceNavigatorHID.current.Translation.ReadValue(), Settings.OrbitInvertTranslation);
-            Vector3 rotation = Vector3.Scale(SpaceNavigatorHID.current.Rotation.ReadValue(), Settings.OrbitInvertRotation);
+			// Store the selection's transforms because the user could have edited them since we last used them via the inspector.
+			if (_wasIdle)
+				StoreSelectionTransforms();
 
-            // Apply sensitivity
-            translation *= Settings.TransSens[Settings.CurrentGear];
-            rotation *= Settings.RotSens;
-            
-            // Apply locks
-            translation.Scale(Settings.GetLocks(DoF.Translation));
-            rotation.Scale(Settings.GetLocks(DoF.Rotation));
-            
-            _camera.Translate(translation, Space.Self);
+			foreach (Transform transform in Selection.GetTransforms(SelectionMode.TopLevel | SelectionMode.Editable)) {
+				if (!_unsnappedRotations.ContainsKey(transform)) continue;
 
-            if (Settings.LockHorizon)
-            {
-                _camera.RotateAround(Tools.handlePosition, Vector3.up, rotation.y);
-                _camera.RotateAround(Tools.handlePosition, _camera.right, rotation.x);
-            }
-            else
-            {
-                _camera.RotateAround(Tools.handlePosition, _camera.up, rotation.y);
-                _camera.RotateAround(Tools.handlePosition, _camera.right, rotation.x);
-                _camera.RotateAround(Tools.handlePosition, _camera.forward, rotation.z);
-            }
+				Transform reference;
+				switch (Settings.CoordSys) {
+					case CoordinateSystem.Camera:
+						reference = sceneView.camera.transform;
+						break;
+					case CoordinateSystem.World:
+						reference = null;
+						break;
+					case CoordinateSystem.Parent:
+						reference = transform.parent;
+						break;
+					case CoordinateSystem.Local:
+						reference = transform;
+						break;
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
 
-            // Update sceneview pivot and repaint view.
-            sceneView.pivot = _pivot.position;
-            sceneView.rotation = _pivot.rotation;
-            sceneView.Repaint();
-        }
+				if (reference == null) {
+					// Move the object in world coordinates.
+					_unsnappedTranslations[transform] += translation;
+					_unsnappedRotations[transform] = rotation * _unsnappedRotations[transform];
+				} else {
+					// Move the object in the reference coordinate system.
+					Vector3 worldTranslation = reference.TransformPoint(translation) -
+											   reference.position;
+					_unsnappedTranslations[transform] += worldTranslation;
+					_unsnappedRotations[transform] = (reference.rotation * rotation * Quaternion.Inverse(reference.rotation)) * _unsnappedRotations[transform];
+				}
 
-        static void Telekinesis(SceneView sceneView)
-        {
-            if (_wasIdle)
-                Undo.IncrementCurrentGroup();
-            Transform[] selection = Selection.GetTransforms(SelectionMode.TopLevel | SelectionMode.Editable);
-            Undo.SetCurrentGroupName("Telekinesis");
-            Undo.RecordObjects(selection, "Telekinesis");
-            
-            // Apply inversion of axes for telekinesis mode.
-            Vector3 translation = Vector3.Scale(SpaceNavigatorHID.current.Translation.ReadValue(), Settings.TelekinesisInvertTranslation);
-            Vector3 rot = Vector3.Scale(SpaceNavigatorHID.current.Rotation.ReadValue(), Settings.TelekinesisInvertRotation);
-            
-            // Apply sensitivity
-            translation *= Settings.TransSens[Settings.CurrentGear];
-            rot *= Settings.RotSens;
-            
-            // Apply locks
-            translation.Scale(Settings.GetLocks(DoF.Translation));
-            rot.Scale(Settings.GetLocks(DoF.Rotation));
+				// Perform rotation with or without snapping.
+				transform.rotation = Settings.SnapRotation ? SnapOnRotation(_unsnappedRotations[transform], Settings.SnapAngle) : _unsnappedRotations[transform];
+				transform.position = Settings.SnapTranslation ? SnapOnTranslation(_unsnappedTranslations[transform], Settings.SnapDistance) : _unsnappedTranslations[transform];
+			}
+		}
+		static void GrabMove(SceneView sceneView) {
+			// Apply inversion of axes for grab move mode.
+			Vector3 translation = Vector3.Scale(SpaceNavigator.Translation, Settings.GrabMoveInvertTranslation);
+			Vector3 rotation = Vector3.Scale(SpaceNavigator.Rotation.eulerAngles, Settings.GrabMoveInvertRotation);
 
-            Quaternion rotation = Quaternion.Euler(rot);
-            
-            // Store the selection's transforms because the user could have edited them since we last used them via the inspector.
-            if (_wasIdle)
-                StoreSelectionTransforms();
+			// Store the selection's transforms because the user could have edited them since we last used them via the inspector.
+			if (_wasIdle)
+				StoreSelectionTransforms();
 
-            foreach (Transform transform in selection)
-            {
-                if (!_unsnappedRotations.ContainsKey(transform)) continue;
+			foreach (Transform transform in Selection.GetTransforms(SelectionMode.TopLevel | SelectionMode.Editable)) {
+				if (!_unsnappedRotations.ContainsKey(transform)) continue;
 
-                Transform reference;
-                switch (Settings.CoordSys)
-                {
-                    case CoordinateSystem.Camera:
-                        reference = sceneView.camera.transform;
-                        break;
-                    case CoordinateSystem.World:
-                        reference = null;
-                        break;
-                    case CoordinateSystem.Parent:
-                        reference = transform.parent;
-                        break;
-                    case CoordinateSystem.Local:
-                        reference = transform;
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
+				// Initialize transform to unsnapped state.
+				transform.rotation = _unsnappedRotations[transform];
+				transform.position = _unsnappedTranslations[transform];
+				Vector3 oldPos = transform.position;
 
-                if (reference == null)
-                {
-                    // Move the object in world coordinates.
-                    _unsnappedTranslations[transform] += translation;
-                    _unsnappedRotations[transform] = rotation * _unsnappedRotations[transform];
-                }
-                else
-                {
-                    // Move the object in the reference coordinate system.
-                    Vector3 worldTranslation = reference.TransformPoint(translation) -
-                                               reference.position;
-                    _unsnappedTranslations[transform] += worldTranslation;
-                    _unsnappedRotations[transform] = (reference.rotation * rotation * Quaternion.Inverse(reference.rotation)) * _unsnappedRotations[transform];
-                }
+				// Rotate with horizon lock.
+				transform.RotateAround(_camera.position, Vector3.up, rotation.y);
+				transform.RotateAround(_camera.position, _camera.right, rotation.x);
 
-                // Perform rotation with or without snapping.
-                transform.rotation = Settings.SnapRotation ? SnapOnRotation(_unsnappedRotations[transform], Settings.SnapAngle) : _unsnappedRotations[transform];
-                transform.position = Settings.SnapTranslation ? SnapOnTranslation(_unsnappedTranslations[transform], Settings.SnapDistance) : _unsnappedTranslations[transform];
-            }
-        }
+				// Interpret SpaceNavigator input in camera space, calculate the effect in world space.
+				Vector3 worldTranslation = sceneView.camera.transform.TransformPoint(translation) -
+											sceneView.camera.transform.position;
+				transform.position += worldTranslation;
 
-        static void GrabMove(SceneView sceneView)
-        {
-            if (_wasIdle)
-                Undo.IncrementCurrentGroup();
-            Transform[] selection = Selection.GetTransforms(SelectionMode.TopLevel | SelectionMode.Editable);
-            Undo.SetCurrentGroupName("GrabMove");
-            Undo.RecordObjects(selection, "GrabMove");
-            
-            // Apply inversion of axes for grab move mode.
-            Vector3 translation = Vector3.Scale(SpaceNavigatorHID.current.Translation.ReadValue(), Settings.GrabMoveInvertTranslation);
-            Vector3 rotation = Vector3.Scale(SpaceNavigatorHID.current.Rotation.ReadValue(), Settings.GrabMoveInvertRotation);
+				// Store new unsnapped state.
+				_unsnappedRotations[transform] = transform.rotation;
+				_unsnappedTranslations[transform] += transform.position - oldPos;   // The rotation also added translation, so calculate the translation delta.
 
-            // Apply sensitivity
-            translation *= Settings.TransSens[Settings.CurrentGear];
-            rotation *= Settings.RotSens;
-            
-            // Apply locks
-            translation.Scale(Settings.GetLocks(DoF.Translation));
-            rotation.Scale(Settings.GetLocks(DoF.Rotation));
-            
-            // Store the selection's transforms because the user could have edited them since we last used them via the inspector.
-            if (_wasIdle)
-                StoreSelectionTransforms();
+				// Perform snapping.
+				transform.position = Settings.SnapTranslation ? SnapOnTranslation(_unsnappedTranslations[transform], Settings.SnapDistance) : _unsnappedTranslations[transform];
+				transform.rotation = Settings.SnapRotation ? SnapOnRotation(_unsnappedRotations[transform], Settings.SnapAngle) : _unsnappedRotations[transform];
+			}
 
-            foreach (Transform transform in selection)
-            {
-                if (!_unsnappedRotations.ContainsKey(transform)) continue;
+			// Move the scene camera.
+			Fly(sceneView, Settings.GrabMoveInvertTranslation, Settings.GrabMoveInvertRotation);
+		}
+		public static void StraightenHorizon() {
+			_camera.rotation = Quaternion.Euler(_camera.rotation.eulerAngles.x, _camera.rotation.eulerAngles.y, 0);
 
-                // Initialize transform to unsnapped state.
-                transform.rotation = _unsnappedRotations[transform];
-                transform.position = _unsnappedTranslations[transform];
-                Vector3 oldPos = transform.position;
+			// Update sceneview pivot and repaint view.
+			SceneView.lastActiveSceneView.pivot = _pivot.position;
+			SceneView.lastActiveSceneView.rotation = _pivot.rotation;
+			SceneView.lastActiveSceneView.Repaint();
+		}
+		#endregion - Navigation -
 
-                // Rotate with horizon lock.
-                transform.RotateAround(_camera.position, Vector3.up, rotation.y);
-                transform.RotateAround(_camera.position, _camera.right, rotation.x);
+		#region - Dummy Camera Rig -
+		/// <summary>
+		/// Sets up a dummy camera rig like the scene camera.
+		/// We can't move the camera, only the SceneView's pivot & rotation.
+		/// For some reason the camera does not always have the same position offset to the pivot.
+		/// This offset is unpredictable, so we have to update our dummy rig each time before using it.
+		/// </summary>
+		private static void InitCameraRig() {
+			_cameraGO = GameObject.Find(CameraName);
+			_pivotGO = GameObject.Find(PivotName);
+			// Create camera rig if one is not already present.
+			if (!_pivotGO) {
+				_cameraGO = new GameObject(CameraName) { hideFlags = HideFlags.HideAndDontSave };
+				_pivotGO = new GameObject(PivotName) { hideFlags = HideFlags.HideAndDontSave };
+			}
+			// Reassign these variables, they get destroyed when entering play mode.
+			_camera = _cameraGO.transform;
+			_pivot = _pivotGO.transform;
+			_pivot.parent = _camera;
 
-                // Interpret SpaceNavigator input in camera space, calculate the effect in world space.
-                Vector3 worldTranslation = sceneView.camera.transform.TransformPoint(translation) -
-                                           sceneView.camera.transform.position;
-                transform.position += worldTranslation;
+			SyncRigWithScene();
+		}
+		/// <summary>
+		/// Position the dummy camera rig like the scene view camera.
+		/// </summary>
+		private static void SyncRigWithScene() {
+			if (SceneView.lastActiveSceneView) {
+				_camera.position = SceneView.lastActiveSceneView.camera.transform.position; // <- this value changes w.r.t. pivot !
+				_camera.rotation = SceneView.lastActiveSceneView.camera.transform.rotation;
+				_pivot.position = SceneView.lastActiveSceneView.pivot;
+				_pivot.rotation = SceneView.lastActiveSceneView.rotation;
+			}
+		}
+		private static void DisposeCameraRig() {
+			Object.DestroyImmediate(_cameraGO);
+			Object.DestroyImmediate(_pivotGO);
+		}
+		#endregion - Dummy Camera Rig -
 
-                // Store new unsnapped state.
-                _unsnappedRotations[transform] = transform.rotation;
-                _unsnappedTranslations[transform] += transform.position - oldPos; // The rotation also added translation, so calculate the translation delta.
-
-                // Perform snapping.
-                transform.position = Settings.SnapTranslation ? SnapOnTranslation(_unsnappedTranslations[transform], Settings.SnapDistance) : _unsnappedTranslations[transform];
-                transform.rotation = Settings.SnapRotation ? SnapOnRotation(_unsnappedRotations[transform], Settings.SnapAngle) : _unsnappedRotations[transform];
-            }
-
-            // Move the scene camera.
-            Fly(sceneView, Settings.GrabMoveInvertTranslation, Settings.GrabMoveInvertRotation);
-        }
-
-        public static void StraightenHorizon()
-        {
-            _camera.rotation = Quaternion.Euler(_camera.rotation.eulerAngles.x, _camera.rotation.eulerAngles.y, 0);
-
-            // Update sceneview pivot and repaint view.
-            SceneView.lastActiveSceneView.pivot = _pivot.position;
-            SceneView.lastActiveSceneView.rotation = _pivot.rotation;
-            SceneView.lastActiveSceneView.Repaint();
-        }
-
-        #endregion - Navigation -
-
-        #region - Dummy Camera Rig -
-
-        /// <summary>
-        /// Sets up a dummy camera rig like the scene camera.
-        /// We can't move the camera, only the SceneView's pivot & rotation.
-        /// For some reason the camera does not always have the same position offset to the pivot.
-        /// This offset is unpredictable, so we have to update our dummy rig each time before using it.
-        /// </summary>
-        private static void InitCameraRig()
-        {
-            _cameraGO = GameObject.Find(CameraName);
-            _pivotGO = GameObject.Find(PivotName);
-            // Create camera rig if one is not already present.
-            if (!_pivotGO)
-            {
-                _cameraGO = new GameObject(CameraName) {hideFlags = HideFlags.HideAndDontSave};
-                _pivotGO = new GameObject(PivotName) {hideFlags = HideFlags.HideAndDontSave};
-            }
-
-            // Reassign these variables, they get destroyed when entering play mode.
-            _camera = _cameraGO.transform;
-            _pivot = _pivotGO.transform;
-            _pivot.parent = _camera;
-
-            SyncRigWithScene();
-        }
-
-        /// <summary>
-        /// Position the dummy camera rig like the scene view camera.
-        /// </summary>
-        private static void SyncRigWithScene()
-        {
-            if (SceneView.lastActiveSceneView)
-            {
-                _camera.position = SceneView.lastActiveSceneView.camera.transform.position; // <- this value changes w.r.t. pivot !
-                _camera.rotation = SceneView.lastActiveSceneView.camera.transform.rotation;
-                _pivot.position = SceneView.lastActiveSceneView.pivot;
-                _pivot.rotation = SceneView.lastActiveSceneView.rotation;
-            }
-        }
-
-        private static void DisposeCameraRig()
-        {
-            Object.DestroyImmediate(_cameraGO);
-            Object.DestroyImmediate(_pivotGO);
-        }
-
-        #endregion - Dummy Camera Rig -
-
-        #region - Snapping -
-
-        public static void StoreSelectionTransforms()
-        {
-            _unsnappedRotations.Clear();
-            _unsnappedTranslations.Clear();
-            foreach (Transform transform in Selection.GetTransforms(SelectionMode.TopLevel | SelectionMode.Editable))
-            {
-                _unsnappedRotations.Add(transform, transform.rotation);
-                _unsnappedTranslations.Add(transform, transform.position);
-            }
-        }
-
-        private static Quaternion SnapOnRotation(Quaternion q, float snap)
-        {
-            Vector3 euler = q.eulerAngles;
-            return Quaternion.Euler(
-                Mathf.RoundToInt(euler.x / snap) * snap,
-                Mathf.RoundToInt(euler.y / snap) * snap,
-                Mathf.RoundToInt(euler.z / snap) * snap);
-        }
-
-        private static Vector3 SnapOnTranslation(Vector3 v, float snap)
-        {
-            return new Vector3(
-                Mathf.RoundToInt(v.x / snap) * snap,
-                Mathf.RoundToInt(v.y / snap) * snap,
-                Mathf.RoundToInt(v.z / snap) * snap);
-        }
-
-        #endregion - Snapping -
-    }
+		#region - Snapping -
+		public static void StoreSelectionTransforms() {
+			_unsnappedRotations.Clear();
+			_unsnappedTranslations.Clear();
+			foreach (Transform transform in Selection.GetTransforms(SelectionMode.TopLevel | SelectionMode.Editable)) {
+				_unsnappedRotations.Add(transform, transform.rotation);
+				_unsnappedTranslations.Add(transform, transform.position);
+			}
+		}
+		private static Quaternion SnapOnRotation(Quaternion q, float snap) {
+			Vector3 euler = q.eulerAngles;
+			return Quaternion.Euler(
+				Mathf.RoundToInt(euler.x / snap) * snap,
+				Mathf.RoundToInt(euler.y / snap) * snap,
+				Mathf.RoundToInt(euler.z / snap) * snap);
+		}
+		private static Vector3 SnapOnTranslation(Vector3 v, float snap) {
+			return new Vector3(
+				Mathf.RoundToInt(v.x / snap) * snap,
+				Mathf.RoundToInt(v.y / snap) * snap,
+				Mathf.RoundToInt(v.z / snap) * snap);
+		}
+		#endregion - Snapping -
+	}
 }
-#endif


### PR DESCRIPTION
I think ViewportController implementation assumes deltaTime in Editor is fixed, therefore doesn't need to be factored into transform updates, yes? Unity logs say it IS fixed, but alas, yet another Unity curveball! 

Actual delta time is not fixed in edit mode. Time.deltaTime simply gives non-refreshed junk placeholder data since the var is intended only for use in play mode.

I thought I was going crazy with the velocity of my space mouse. I'm a drummer, so my finger coordination is pretty sensitive to subtle timing shifts. I blamed my own lack of muscle memory for the first hour. After that, no, there was a disturbance in the force.

I logged a DIY deltaTime alongside Unity's Time.deltaTime and found that Time.deltaTime is junk, which explains why my space mouse was consistently hurling my camera into hyperspace whenever my laptop fan turned off. I wasn't such a horrible driver after all!

The fix:
ViewportController's translation actions must factor in deltaTime... familiar song-and-dance, except it must be done w/ DIY deltaTime since Time.deltaTime is useless outside play mode. Also, I multiplied in a const of 100f to get us back in the same sensitivity ballpark post-delta. That might be better handled in sensitivity settings in a future push. 

I have only applied this fix for Fly mode translation. Haven't had time to fix rotation yet, since the bug is only really noticeable if you try to hold a consistent velocity for a few seconds (which we almost never need for rotation).

Also, I haven't had a chance to try other modes yet, but translation in Fly mode is now buttery smooth. The same fix could be done to all translations and rotations in all modes if you really went to make the whole plugin buttery smooth.

Cheers!