### PR TITLE
Prevent input when the Unity window isn't in focus

### DIFF
--- a/Editor/ViewportController.cs
+++ b/Editor/ViewportController.cs
@@ -75,6 +75,7 @@ namespace SpaceNavigatorDriver
                 GameView = assembly.GetType("UnityEditor.GameView");
             }
 
+            if (!EditorApplication.isFocused) return;
             if (Application.isPlaying && Settings.RuntimeEditorNav && Settings.RuntimeEditorNavSuspendOnGameViewFocus && GameView.IsAssignableFrom(EditorWindow.focusedWindow?.GetType())) return;
 
             SceneView sceneView = SceneView.lastActiveSceneView;


### PR DESCRIPTION
Prevent input when the Unity window isn't in focus. Important for using the SpaceMouse in other apps like Blender.