### PR TITLE
Fix WirelessHID ignores yaw, and uses roll as yaw.

### DIFF
--- a/Runtime/SpaceNavigatorWirelessHID.cs
+++ b/Runtime/SpaceNavigatorWirelessHID.cs
@@ -30,8 +30,8 @@ namespace SpaceNavigatorDriver
         [InputControl(name = "translation/z", offset = 2, format = "SHRT", parameters = "scale=true, scaleFactor=-10")]
         [InputControl(name = "rotation", format = "VC3S", layout = "Vector3", displayName = "Rotation")] 
         [InputControl(name = "rotation/x", offset = 6, format = "SHRT", parameters = "scale=true, scaleFactor=-80")] 
-        [InputControl(name = "rotation/y", offset = 8, format = "SHRT", parameters = "scale=true, scaleFactor=80")] 
-        [InputControl(name = "rotation/z", offset = 10, format = "SHRT", parameters = "scale=true, scaleFactor=80")]
+        [InputControl(name = "rotation/y", offset = 10, format = "SHRT", parameters = "scale=true, scaleFactor=80")] 
+        [InputControl(name = "rotation/z", offset = 8, format = "SHRT", parameters = "scale=true, scaleFactor=80")]
         public ReportFormat1 report1;
 
         // 3rd report


### PR DESCRIPTION
## Problem
When using the 3DConnexion SpaceNavigator Wireless, yaw actions have no effect, and the roll action causes what you would expect when using the yaw action.

## Cause
@jondowen identified that the offsets were incorrect. See https://github.com/PatHightree/SpaceNavigator/issues/31#issuecomment-1370767804

## Fix
I applied @jondowen's suggested changes and confirmed that everything works as expected now. Thanks! You are a lifesaver. ❤️ 