### PR TITLE
Fix static constructors not invoked in build

### DIFF
--- a/Runtime/SpaceNavigatorEnterpriseHID.cs
+++ b/Runtime/SpaceNavigatorEnterpriseHID.cs
@@ -68,6 +68,13 @@ namespace SpaceNavigatorDriver
             DebugLog("SpaceNavigatorEnterpriseHID : Register layout for SpaceNavigator Enterprise productId:0x????");
         }
 
+        // In the player, trigger the calling of our static constructor
+        // by having an empty method annotated with RuntimeInitializeOnLoadMethod.
+        [RuntimeInitializeOnLoadMethod]
+        private static void Init()
+        {
+        }
+        
         // When one of our custom devices is removed, we want to make sure that if
         // it is the '.current' device, we null out '.current'.
         public override unsafe void OnStateEvent(InputEventPtr eventPtr)

--- a/Runtime/SpaceNavigatorWirelessHID.cs
+++ b/Runtime/SpaceNavigatorWirelessHID.cs
@@ -65,6 +65,14 @@ namespace SpaceNavigatorDriver
                     .WithCapability("productId", 0xc62e)); // SpaceMouse Wireless (cabled)
             DebugLog("SpaceNavigatorWirelessHID : Register layout for SpaceNavigator/SpaceMouse Wireless (cabled) productId:0xc62e");
         }
+        
+        // In the player, trigger the calling of our static constructor
+        // by having an empty method annotated with RuntimeInitializeOnLoadMethod.
+        [RuntimeInitializeOnLoadMethod]
+        private static void Init()
+        {
+        }
+        
         // When one of our custom devices is removed, we want to make sure that if
         // it is the '.current' device, we null out '.current'.
         public override unsafe void OnStateEvent(InputEventPtr eventPtr)


### PR DESCRIPTION
Fix static constructors not invoked in build for SpaceNavigatorWirelessHID and SpaceNavigatorEnterpriceHID due to [RuntimeInitializeOnLoadMethod] only being present in the base class and thus only triggering static constructor for base class.