### PR TITLE
Add Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It can also be used at runtime via scripting.
 
 The default mode is **Fly** mode and when you're flying around, this driver keeps your horizon horizontal.  
 So you don't have to worry about ending up upside down, just go where you want and get some work done.  
-To comfortably navigate large areas and minute details, you can easilly switch between 3 customizable sensitivity presets.  
+To comfortably navigate large areas and minute details, you can easily switch between 3 customizable sensitivity presets.  
 To move stuff around, you can use 2 modes: Telekinesis and GrabMove.  
 In **Telekinesis** mode, you can move the stuff you selected with the SpaceNavigator, while your camera stays put.  
 (this mode can be operated in Camera-, World-, Parent- and Local coordinates)  
@@ -15,6 +15,9 @@ Translation can be snapped to a grid and rotation can be angle-snapped.
 
 If you encounter issues, please report them via the project's [Github Issues](https://github.com/PatHightree/SpaceNavigator/issues) page.  
 If you have feedback, please use this [thread](https://discussions.unity.com/t/spacenavigator-driver-opensource/504914) on the Unity Discussions site.
+
+## Linux Support
+SpaceNavigator works on Linux. Click [here](./linux.md) for setup instructions.
 
 ## What's new in 2.0.0 ?
 ### 3DConnexion driver no longer required

--- a/Runtime/Settings/Settings.cs
+++ b/Runtime/Settings/Settings.cs
@@ -395,9 +395,11 @@ namespace SpaceNavigatorDriver {
 			GUILayout.Space(10);
 			GUILayout.Label("Runtime Behavior");
 			RuntimeEditorNav = GUILayout.Toggle(RuntimeEditorNav, "Runtime Editor Navigation");
+#if !UNITY_EDITOR_LINUX
 			EditorGUI.BeginDisabledGroup(true);
 			GUILayout.TextArea("Only works when scene view has focus and requires\n'Project Settings/Input System Package/Settings/Play Mode Input Behavior'\nto be set to\n'All Devices Respect Game View Focus'");
 			EditorGUI.EndDisabledGroup();
+#endif
 
 			#endregion
 			
@@ -406,8 +408,11 @@ namespace SpaceNavigatorDriver {
 			GUILayout.Space(10);
 			Assembly assembly = typeof(SpaceNavigatorHID).Assembly;
 			PackageInfo packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(assembly);
-			string version = packageInfo.version;
-			GUILayout.Label($"Version {version}");
+			if (packageInfo != null)
+			{
+				string version = packageInfo.version;
+				GUILayout.Label($"Version {version}");
+			}
 
 			#endregion
 			

--- a/Runtime/SpaceNavigatorLinuxDriver.cs
+++ b/Runtime/SpaceNavigatorLinuxDriver.cs
@@ -1,0 +1,207 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using System;
+using System.Runtime.InteropServices;
+using UnityEditor.Callbacks;
+
+namespace SpaceNavigatorDriver
+{
+    [Serializable]
+    [InitializeOnLoad]
+    public class SpaceNavigatorLinuxDriver
+    {
+        [DllImport("libspnav.so.0")]
+        private static extern int spnav_open();
+
+        [DllImport("libspnav.so.0")]
+        private static extern SpnavEventType spnav_wait_event(ref SpnavEvent ev);
+
+
+        [DllImport("libspnav.so.0")]
+        private static extern SpnavEventType spnav_poll_event(ref SpnavEvent ev);
+
+        [DllImport("libspnav.so.0")]
+        private static extern void spnav_close();
+
+        /* Control device LED
+         * SPNAV_CFG_LED_OFF(0) | SPNAV_CFG_LED_ON(1) | SPNAV_CFG_LED_AUTO(2)
+         * cfgfile option: led
+         */
+        [DllImport("libspnav.so.0")]
+        private static extern Int32 spnav_cfg_set_led(Int32 state);
+
+        [DllImport("libspnav.so.0")]
+        private static extern Int32 spnav_cfg_get_led();	/* returns led setting, -1 on error */
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        struct SpnavEventMotion
+        {
+            // public Int32 type; /* SPNAV_EVENT_MOTION */
+            public Int32 x, y, z;
+            public Int32 rx, ry, rz;
+            public UInt32 period;
+            public UInt32 data;
+        };
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        struct SpnavEventButton
+        {
+            public Int32 type; /* SPNAV_EVENT_BUTTON or SPNAV_EVENT_RAWBUTTON */
+            public Int32 press;
+            public Int32 bnum;
+        };
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        struct SpnavEventDev
+        {
+            public Int32 type; /* SPNAV_EVENT_DEV */
+            public Int32 op; /* SPNAV_DEV_ADD / SPNAV_DEV_RM */
+            public Int32 id;
+            public Int32 devtype; /* see spnav_dev_type() */
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+            public Int32[] usbid; /* USB id if it's a USB device, 0:0 if it's a serial device */
+        };
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct SpnavEventCfg
+        {
+            public Int32 type; /* SPNAV_EVENT_CFG */
+            public Int32 cfg; /* same as protocol REQ_GCFG* enum */
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+            public Int32[] data; /* same as protocol response data 0-5 */
+        };
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct SpnavEventAxis
+        {
+            public Int32 type; /* SPNAV_EVENT_RAWAXIS */
+            public Int32 idx; /* axis number */
+            public Int32 value; /* value */
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        struct SpnavEvent
+        {
+            public Int32 type;
+            public SpnavEventMotion motion;
+            public SpnavEventButton button;
+            public SpnavEventDev dev;
+            public SpnavEventCfg cfg;
+            public SpnavEventAxis axis;
+        }
+
+        private enum SpnavEventType
+        {
+            SPNAV_EVENT_ANY = 0, /* used by spnav_remove_events() */
+            SPNAV_EVENT_MOTION,
+            SPNAV_EVENT_BUTTON, /* includes both press and release */
+            SPNAV_EVENT_DEV, /* add/remove device event */
+            SPNAV_EVENT_CFG, /* configuration change event */
+            SPNAV_EVENT_RAWAXIS,
+            SPNAV_EVENT_RAWBUTTON
+        }
+
+        private static bool isConnected = false;
+        private static float sliderX = 0f;
+        private static float sliderY = 0f;
+        private static float sliderZ = 0f;
+        private static float sliderRX = 0f;
+        private static float sliderRY = 0f;
+        private static float sliderRZ = 0f;
+        private static SpnavEvent ev = new SpnavEvent();
+
+        public static readonly SpaceNavigatorLinuxDriver Instance = new SpaceNavigatorLinuxDriver();
+
+        public static bool IsConnected => isConnected;
+        public static Vector3 Translation => new Vector3(sliderX, sliderY, sliderZ) / 350f;
+        public static Vector3 Rotation => new Vector3(sliderRX, sliderRY, sliderRZ) / 350f;
+
+        static SpaceNavigatorLinuxDriver()
+        {
+            Init();
+        }
+
+        static void Init()
+        {
+            Connect();
+
+            if (isConnected)
+            {
+                EditorApplication.update += Poll;
+            }
+        }
+
+        [DidReloadScripts]
+        static void OnReload()
+        {
+            Disconnect();
+            Init();
+        }
+
+
+        public static void SetLEDStatus(SpaceNavigatorHID.LedStatus status)
+        {
+            Int32 value = status == SpaceNavigatorHID.LedStatus.On ? 1 : 0;
+            spnav_cfg_set_led(value);
+        }
+
+        private static void Poll()
+        {
+            // Poll for events
+            SpnavEventType result = spnav_poll_event(ref ev);
+
+            if (result == SpnavEventType.SPNAV_EVENT_MOTION) // SPNAV_EVENT_MOTION
+            {
+                sliderX = ev.motion.x;
+                sliderY = ev.motion.y;
+                sliderZ = ev.motion.z;
+                sliderRX = ev.motion.rx;
+                sliderRY = ev.motion.ry;
+                sliderRZ = ev.motion.rz;
+            }
+            else
+            {
+                sliderX = 0;
+                sliderY = 0;
+                sliderZ = 0;
+                sliderRX = 0;
+                sliderRY = 0;
+                sliderRZ = 0;
+            }
+        }
+
+        private static void Connect()
+        {
+            int result = spnav_open();
+            if (result == -1)
+            {
+                Debug.LogError($"Failed to connect to spacenavd");
+            }
+
+            isConnected = true;
+            DebugLog("Connected to spacenavd");
+        }
+
+        private static void Disconnect()
+        {
+            if (isConnected)
+            {
+                spnav_close();
+                isConnected = false;
+                DebugLog("Disconnected from spacenavd");
+            }
+        }
+
+        private static void DebugLog(string _message)
+        {
+#if SPACENAVIGATOR_DEBUG
+            Debug.Log(_message);
+#endif
+        }
+
+    }
+}
+#endif

--- a/Runtime/SpaceNavigatorLinuxDriver.cs.meta
+++ b/Runtime/SpaceNavigatorLinuxDriver.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f8f54df3a5e34369880b6102483a4713
+timeCreated: 1768340604

--- a/linux.md
+++ b/linux.md
@@ -1,0 +1,30 @@
+# SpaceNavigator Linux Support
+
+Unity's Input System does not support HID devices on Linux, so we cannot use it. Thankfully, there already is
+a good open-source driver for 3DConnexion 6DOF devices called [spacenavd](https://github.com/FreeSpacenav/spacenavd), 
+so we can rely on it instead.
+
+## Installation
+
+### 1. Install [spacenavd](https://github.com/FreeSpacenav/spacenavd).
+
+For Ubuntu and other Debian-like systems, you can just `apt install spacenavd`.
+
+Before you continue, make sure the driver works by trying it out in another application like Blender.
+
+### 2. Make spacenavd listen on the correct socket
+
+Create a file under `/etc/spnavrc` with the following contents:
+
+    socket=/var/run/spnav.sock
+
+Then restart the spacenavd service.
+
+If you are successful, the output of `file /var/run/spnav.sock` will look like this:
+
+    /var/run/spnav.sock: socket
+
+### 3. Install SpaceNavigator normally
+
+... as per instructions in the main [README](./README.md) file. Your 6DOF device should now work in the editor.
+If it doesn't, try unchecking the "Only navigate when Unity has focus" option.


### PR DESCRIPTION
Hi!

This PR is more of an RFC to see if you'd be interested in accepting such a change.

The main challenge here is that Unity's [InputSystem does not support non-joystick HID devices on Linux](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.18/manual/HID.html#:~:text=For%20example%2C%20on%20Linux%2C%20the%20system%20supports%20gamepad%20and%20joystick%20HIDs%20through%20SDL%2C%20but%20doesn%27t%20support%20other%20HIDs). So, the options are to
a) either somehow force SDL to accept the SpaceMouse as some kind of 6-axis joystick, or 
b) do what Blender is doing, so just use the [existing open-source driver for Linux](https://github.com/FreeSpacenav/spacenavd). (I have no affiliation with its author(s), btw)

I went with the second option, and it works really well. However, the problem with shunning InputSystem just on Linux is that it necessitates these horrible `#if`s in `ViewController.cs` and also in run-time examples (not pictured in this commit).

We could potentially solve this by wrapping it with an extra layer of abstraction, so the user would say something like `SpaceNavigator.Translation`, and that would retrieve the translation value from either `SpaceNavigatorHID.current` or `SpaceNavigatorLinuxDriver`, depending on the platform. But this kind of runs contrary to your concept (I think?) of making SpaceNavigator some kind of a submodule to InputSystem.

I'm curious about your thoughts, and also feel free to ignore this PR - I'm perfectly fine with just using my fork. And BTW, thanks for creating this UnityEditor plugin, it works REALLY well.